### PR TITLE
handle gcfg struct tags when reading environment variables

### DIFF
--- a/gcfgenv_test.go
+++ b/gcfgenv_test.go
@@ -403,8 +403,6 @@ f2 = dogs
 }
 
 func (s *Suite) TestGcfgTags(c *check.C) {
-	c.ExpectFailure("not yet implemented")
-
 	type sec1 struct {
 		F1 string `gcfg:"another-name"`
 	}


### PR DESCRIPTION
The gcfg.ReadInto function handles gcfg struct tags, but we need to use them when reading environment variables (when present). This gcfgTagOrStructName() function will return a gcfg tag or fall back to the field.Name if no such struct tag is present. It also replaces dashes by underscores to follow env var and field naming conventions.


As an aside:

Reading here: https://pkg.go.dev/gopkg.in/gcfg.v1#hdr-Data_structure

> The mapping of each section or variable name to fields is done either based on the "gcfg" struct tag or by matching the name of the section or variable, ignoring case. In the latter case, hyphens '-' in section and variable names correspond to underscores '_' in field names.

I suspect this means that our test case is proper and the `another-name` struct tag _should_ be overridden by the `ANOTHER_NAME` env var. However, I wanted to be sure, since the "former" case (of a gcfg struct tag) does _not_ seem to follow the convention of replacing dashes by underscores. 

Close #1 