### PR TITLE
Add multi array append behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ rules:
   tag](https://pkg.go.dev/gopkg.in/gcfg.v1#hdr-Data_structure)) are converted to
   uppercase.
 * Slice fields use `,` as a separator.
+* Consistent with the `gcfg` package, slices are appended rather than replaced.
 * Dashes are converted to underscores.
 * Subsection names are left as-is.
 

--- a/gcfgenv.go
+++ b/gcfgenv.go
@@ -125,7 +125,11 @@ func setGcfgWithEnvMap(ref reflect.Value, prefix string, env map[string]string) 
 				if err != nil {
 					return err
 				}
-				f.Set(newRef)
+				if f.Kind() == reflect.Slice {
+					f.Set(reflect.AppendSlice(f, newRef))
+				} else {
+					f.Set(newRef)
+				}
 			}
 			continue
 		}
@@ -170,7 +174,11 @@ func setGcfgWithEnvMap(ref reflect.Value, prefix string, env map[string]string) 
 					if err != nil {
 						return err
 					}
-					f.Set(newRef)
+					if f.Kind() == reflect.Slice {
+						f.Set(reflect.AppendSlice(f.Elem(), newRef))
+					} else {
+						f.Set(newRef)
+					}
 				}
 			}
 			if len(matchingEnv) == 0 {
@@ -212,7 +220,11 @@ func setGcfgWithEnvMap(ref reflect.Value, prefix string, env map[string]string) 
 					if err != nil {
 						return err
 					}
-					f.Elem().Field(j).Set(newRef)
+					if f.Elem().Field(j).Kind() == reflect.Slice {
+						f.Elem().Field(j).Set(reflect.AppendSlice(f.Elem().Field(j).Elem(), newRef))
+					} else {
+						f.Elem().Field(j).Set(newRef)
+					}
 					// TODO: Does this have any unfortunate
 					// side-effects?
 					delete(matchingEnv, e)

--- a/gcfgenv_test.go
+++ b/gcfgenv_test.go
@@ -437,6 +437,47 @@ another-name = value
 	c.Check(cfg, check.DeepEquals, configFilledWithEnvVars)
 }
 
+func (s *Suite) TestSliceEnvVars(c *check.C) {
+	type sec struct {
+		Field []string
+	}
+	type config struct {
+		Sec1 sec
+		Sec2 sec
+		Sec3 sec
+	}
+
+	var err error
+	var cfg config
+	var configFilledWithEnvVars config
+	var r *strings.Reader
+
+	os.Setenv("APPNAME_SEC1_FIELD", "one,two,three")
+	os.Setenv("APPNAME_SEC2_FIELD", "a,b,c")
+	os.Setenv("APPNAME_SEC3_FIELD", "1,2,3")
+	defer func() {
+		os.Unsetenv("APPNAME_SEC1_FIELD")
+		os.Unsetenv("APPNAME_SEC2_FIELD")
+		os.Unsetenv("APPNAME_SEC3_FIELD")
+	}()
+
+	cfg = config{
+		// set a default
+		Sec2: sec{
+			[]string{"q", "r", "s"},
+		},
+	}
+	configFilledWithEnvVars = config{
+		Sec1: sec{[]string{"hi", "one", "two", "three"}},
+		Sec2: sec{[]string{"q", "r", "s", "a", "b", "c"}},
+		Sec3: sec{[]string{"1", "2", "3"}},
+	}
+	r = strings.NewReader("[Sec1]\nField=hi")
+	err = ReadWithEnvInto(r, "APPNAME", &cfg)
+	c.Check(err, check.IsNil)
+	c.Check(cfg, check.DeepEquals, configFilledWithEnvVars)
+}
+
 func Test(t *testing.T) {
 	_ = check.Suite(&Suite{})
 	check.TestingT(t)


### PR DESCRIPTION
The `gcfg` package appends arrays, as shown in the below example:

```
package main

import (
	"gopkg.in/gcfg.v1"
	"os"
	"fmt"
)

func check(e error) {
	if e != nil {
		panic(e)
	}
}

type TestConfig struct {
	One []string
}

type Config struct {
	Test TestConfig
}

func main() {

	cfg := Config{}

	c := []byte("[test]\none=two\none=three\n")
	err := os.WriteFile("/tmp/test", c, 0644)
	check(err)

	gcfg.ReadFileInto(&cfg, "/tmp/test")
	fmt.Printf("Config Setting: %v\n", cfg.Test.One)
	gcfg.ReadFileInto(&cfg, "/tmp/test")
	fmt.Printf("Config Setting: %v\n", cfg.Test.One)
}
```

resulting in:
```
Config Setting: [two three]
Config Setting: [two three two three]
```

`gcfgenv`, by contrast, has overwritten arrays to date. This PR adds tests for this behavior and alters `gcfgenv` to be consistent with `gcfg`. However, a noteworthy side effect:
> parsing the same environment variables into the same config object twice will duplicate values in the output

